### PR TITLE
ローリングハッシュ 最長共通接頭辞と辞書順比較を実装

### DIFF
--- a/Python_classes/RollingHash.py
+++ b/Python_classes/RollingHash.py
@@ -107,7 +107,7 @@ class RollingHash():
             c1,c2='?','?'
             if pos1+now<self.N:
                 c1=self.S[pos1+now]
-            if pos2+now+1<self.N:
+            if pos2+now<self.N:
                 c2=self.S[pos2+now]
             
             if c1>c2:


### PR DESCRIPTION
**最長共通接頭辞**
- 2つの部分文字列の最長共通接頭辞の長さを求める
- 二分探索でがんばる
- 時間計算量O(logN)

**辞書順比較**
- 最長共通接頭辞から1つ後ろの文字で比較
- 最長共通接頭辞のメソッドを呼ぶのと地道な場合分けでがんばる
- 時間計算量O(logN)